### PR TITLE
Add yamllint to our travis-ci runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 dist: trusty
 sudo: required
 language: go
@@ -18,6 +19,7 @@ before_install:
   - sudo apt-get install npm && npm install -g markdown-link-check
 
 script:
+  - make yamllint
   - make check_links || true
   - make lint
   - make

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -169,4 +169,14 @@ test-examples:
 test-cover:
 	$(call test_cover_only)
 
-.PHONY: build get-dep dep-install dep-update test lint clean
+# Install yamllint
+get-yamllint:
+	pip install --user yamllint
+
+# Lint the yaml files
+yamllint: get-yamllint
+	@echo "=> linting the yaml files"
+	yamllint -c .yamllint.yml $(shell git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
+
+.PHONY: build get-dep dep-install dep-update test lint clean \
+	get-yamllint yamllint

--- a/plugins/k8scrd/crd_yaml/example_ipampool.yaml
+++ b/plugins/k8scrd/crd_yaml/example_ipampool.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sfccontroller.ligato.github.com/v1alpha1
 kind: IpamPool
 metadata:

--- a/plugins/k8scrd/crd_yaml/example_networknode.yaml
+++ b/plugins/k8scrd/crd_yaml/example_networknode.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sfccontroller.ligato.github.com/v1alpha1
 kind: NetworkNode
 metadata:
@@ -5,7 +6,7 @@ metadata:
   labels:
     bar: foo
 spec:
-  node_type: host 
+  node_type: host
   interfaces:
     - name: GigabitEthernet2/0/1
       if_type: ethernet

--- a/plugins/k8scrd/crd_yaml/example_networknodeoverlay.yaml
+++ b/plugins/k8scrd/crd_yaml/example_networknodeoverlay.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sfccontroller.ligato.github.com/v1alpha1
 kind: NetworkNodeOverlay
 metadata:
@@ -10,5 +11,4 @@ spec:
   vxlan_mesh_parms:
     vni_range_start: 5000
     vni_range_end: 5999
-    #loopback_ipam_pool_name: vxlan_loopback_pool
     network_node_interface_label: vxlan

--- a/plugins/k8scrd/crd_yaml/example_networkservice.yaml
+++ b/plugins/k8scrd/crd_yaml/example_networkservice.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sfccontroller.ligato.github.com/v1alpha1
 kind: NetworkService
 metadata:

--- a/topologies/vxlanhubandspoke/l2mp/vxlanl2mp.yaml
+++ b/topologies/vxlanhubandspoke/l2mp/vxlanl2mp.yaml
@@ -1,3 +1,4 @@
+---
 sfc_controller_config_version: 2
 description: 3 node with 1 nic port, host-host vxlan mesh, vnf on each node
 
@@ -5,7 +6,7 @@ system_parameters:
   ipam_pools:
     - name: vxlan_loopback_pool
       network: 111.111.111.0/24
-      
+
 vnf_to_node_map:
   - vnf: vnf1
     node: vswitch3
@@ -32,7 +33,7 @@ nodes:
         ip_addresses:
           - "10.100.2.2/24"
         custom_labels:
-          - vxlan 
+          - vxlan
 
   - name: vswitch3
     node_type: host
@@ -42,7 +43,7 @@ nodes:
         ip_addresses:
           - "10.100.3.3/24"
         custom_labels:
-          - vxlan         
+          - vxlan
 
   - name: router-a
     node_type: external
@@ -83,7 +84,7 @@ vnf_services:
           - vnf: vnf2
             interface: port1
           - vnf: vnf3
-            interface: port1                    
+            interface: port1
 
 vnf_service_meshes:
   - name: router-a-hub-and-spoke

--- a/topologies/vxlanmesh/l2mp/vxlanl2mp.yaml
+++ b/topologies/vxlanmesh/l2mp/vxlanl2mp.yaml
@@ -1,3 +1,4 @@
+---
 sfc_controller_config_version: 2
 description: 3 node with 1 nic port, host-host vxlan mesh, vnf on each node
 
@@ -5,7 +6,7 @@ system_parameters:
   ipam_pools:
     - name: vxlan_loopback_pool
       network: 111.111.111.0/24
-      
+
 vnf_to_node_map:
   - vnf: vnf1
     node: vswitch1
@@ -32,7 +33,7 @@ nodes:
         ip_addresses:
           - "10.100.2.2/24"
         custom_labels:
-          - vxlan 
+          - vxlan
 
   - name: vswitch3
     node_type: host
@@ -42,7 +43,7 @@ nodes:
         ip_addresses:
           - "10.100.3.3/24"
         custom_labels:
-          - vxlan         
+          - vxlan
 
 vnf_services:
   - name: service1
@@ -73,7 +74,7 @@ vnf_services:
           - vnf: vnf2
             interface: port1
           - vnf: vnf3
-            interface: port1                    
+            interface: port1
 
 vnf_service_meshes:
   - name: inter_host_vxlan_mesh

--- a/topologies/vxlanmesh/l2pp/vxlanl2pp.yaml
+++ b/topologies/vxlanmesh/l2pp/vxlanl2pp.yaml
@@ -1,3 +1,4 @@
+---
 sfc_controller_config_version: 2
 description: 3 nodes with 1 nic port, host-host vxlan mesh, vnf on each node
 
@@ -52,7 +53,7 @@ nodes:
         if_type: ethernet
         ip_addresses:
           - "10.100.3.1/16"
-       
+
 vnf_services:
   - name: service1
     vnfs:
@@ -66,8 +67,8 @@ vnf_services:
         forwarding:
           - type: l2xc
             l2xc_interfaces:
-                - port1
-                - port2   
+              - port1
+              - port2
       - name: vnf2
         node: vswitch2
         vnf_type: vppcontainer
@@ -79,8 +80,8 @@ vnf_services:
         forwarding:
           - type: l2xc
             l2xc_interfaces:
-                - port1
-                - port2   
+              - port1
+              - port2
       - name: vnf3
         node: vswitch3
         vnf_type: vppcontainer
@@ -92,8 +93,8 @@ vnf_services:
         forwarding:
           - type: l2xc
             l2xc_interfaces:
-                - port1
-                - port2
+              - port1
+              - port2
     connections:
       - conn_type: l2pp
         vnf_service_mesh: inter_host_vxlan_mesh
@@ -108,7 +109,7 @@ vnf_services:
           - vnf: vnf2
             interface: port2
           - vnf: vnf3
-            interface: port1           
+            interface: port1
 
 vnf_service_meshes:
   - name: inter_host_vxlan_mesh
@@ -119,4 +120,3 @@ vnf_service_meshes:
       vni_range_end: 5999
       loopback_ipam_pool_name: vxlan_loopback_pool
       outgoing_interface_label: vxlan
-

--- a/yaml/jb.yaml
+++ b/yaml/jb.yaml
@@ -1,14 +1,15 @@
+---
 sfc_controller_config_version: 2
 description: 2 vnf chains spanning 2 hosts, memif's and vxlan tunnels
 
-ipam_pools: # allocate internode vxlan mesh enpoints from a pool
+ipam_pools:  # allocate internode vxlan mesh enpoints from a pool
   - name: vxlan_loopback_pool
     scope: system
-    network: 192.168.20.0/24 # allocate ip's from 192.168.20.30 to 192.168.20.40
+    network: 192.168.20.0/24  # allocate ip's from 192.168.20.30 to 192.168.20.40
     start_range: 30
     end_range: 40
 
-vnf_to_node_map: # this mapping can be static or supplied by k8s discovering pod placement
+vnf_to_node_map:  # this mapping can be static or supplied by k8s discovering pod placement
   - vnf: vnf1
     node: k8s-worker1
   - vnf: vnf2

--- a/yaml/jjj.yaml
+++ b/yaml/jjj.yaml
@@ -1,3 +1,4 @@
+---
 sfc_controller_config_version: 2
 description: Basic Example static config for hosting 2 containers with a vnf-agent and vpp
 
@@ -22,14 +23,14 @@ vnf_services:
           - name: agent1_afpacket1
             if_type: veth
             ip_addresses:
-            - 10.0.0.10/24
+              - 10.0.0.10/24
       - name: agent_2
         vnf_type: vppcontainer
         interfaces:
           - name: agent2_afpacket1
             if_type: veth
             ip_addresses:
-            - 10.0.0.11/24
+              - 10.0.0.11/24
     connections:
       - conn_type: l2mp
         use_node_l2bd: east-west-bd

--- a/yaml/nn.yaml
+++ b/yaml/nn.yaml
@@ -1,12 +1,13 @@
+---
 sfc_controller_config_version: 2
 description: ""
 
 network_nodes:
   - metadata:
-     name: john
-     labels:
-     - john1
-     - john2
+    name: john
+    labels:
+      - john1
+      - john2
     spec:
       node_type: host
       interfaces:
@@ -18,10 +19,10 @@ network_nodes:
               - "10.100.1.1/24"
             mac_address: 02:00:00:00:00:01
   - metadata:
-     name: maciek
-     labels:
-     - maciek1
-     - maciek2
+    name: maciek
+    labels:
+      - maciek1
+      - maciek2
     spec:
       node_type: host
       interfaces:

--- a/yaml/ons_contiv_ligato_demo.yaml
+++ b/yaml/ons_contiv_ligato_demo.yaml
@@ -1,13 +1,14 @@
+---
 sfc_controller_config_version: 2
 description: 2 vnf chains spanning 2 hosts, memif's and vxlan tunnels
 
-ipam_pools: # allocate internode vxlan mesh enpoints from a pool
+ipam_pools:  # allocate internode vxlan mesh enpoints from a pool
   - metadata:
       name: vxlan_loopback_pool
       labels:
     spec:
       scope: system
-      network: 192.168.30.0/24 # allocate ip's from 192.168.30.200 to 192.168.30.205
+      network: 192.168.30.0/24  # allocate ip's from 192.168.30.200 to 192.168.30.205
       start_range: 200
       end_range: 205
 
@@ -33,7 +34,7 @@ network_nodes:
               - "192.168.16.1/24"
         - metadata:
             name: vxlan_endpoint
-          spec:        
+          spec:
             if_type: vxlan_tunnel
             ip_addresses:
               - "200.200.200.1/24"
@@ -53,7 +54,7 @@ network_nodes:
               - "192.168.16.2/24"
         - metadata:
             name: vxlan_endpoint
-          spec:        
+          spec:
             if_type: vxlan_tunnel
             ip_addresses:
               - "200.200.200.2/24"
@@ -73,11 +74,11 @@ network_nodes:
               - "192.168.16.3/24"
         - metadata:
             name: vxlan_endpoint
-          spec:        
+          spec:
             if_type: vxlan_tunnel
             ip_addresses:
               - "200.200.200.3/24"
-                  
+
 network_services:
   - metadata:
       name: l2pp_service_chain1

--- a/yaml/vxlan.yaml
+++ b/yaml/vxlan.yaml
@@ -1,3 +1,4 @@
+---
 sfc_controller_config_version: 2
 
 ipam_pools:
@@ -8,21 +9,10 @@ ipam_pools:
       network: 10.10.1.0/24
       start_range: 1
       end_range: 254
-#  - metadata:
-#      name: vxlan_loopback_pool
-#    spec:
-#      scope: system
-#      network: 200.200.200.0/24
-#      start_range: 200
-#      end_range: 205
 
 network_pod_to_node_map:
   - pod: MOB
     node: ts1-host1
-#  - pod: BIA_1
-#    node: ts1-host1
-#  - pod: BIA_2
-#    node: ts1-host1
 
 network_nodes:
   - metadata:
@@ -30,31 +20,16 @@ network_nodes:
     spec:
       node_type: host
       interfaces:
-        - name: GIGE_MOB # mobility network
+        - name: GIGE_MOB  # mobility network
           labels:
             - mob_label
           if_type: ethernet
-        - name: GIGE_INTER_HOST # inter-host network
+        - name: GIGE_INTER_HOST  # inter-host network
           labels:
             - vxlan
           ip_addresses:
             - 5.5.5.1/32
           if_type: ethernet
-#  - metadata:
-#      name: ts1-host2
-#    spec:
-#      node_type: host
-#      interfaces:
-#        - name: GIGE_MOB # mobility network
-#          labels:
-#            - mob_label
-#          if_type: ethernet
-#        - name: GIGE_INTER_HOST # inter-host network
-#          labels:
-#            - vxlan
-#          ip_addresses:
-#            - 5.5.6.1/32
-#          if_type: ethernet
 
 network_services:
   - metadata:
@@ -70,40 +45,12 @@ network_services:
                 if_type: memif
                 ipam_pool_names:
                   - network_service_pool
-#              - name: bia
-#                if_type: memif
-#                ipam_pool_names:
-#                  - network_service_pool
-#        - metadata:
-#            name: BIA_1
-#          spec:
-#            pod_type: nonvppcontainer
-#            interfaces:
-#              - name: bia
-#                if_type: veth
-#                ipam_pool_names:
-#                  - network_service_pool
-#        - metadata:
-#            name: BIA_2
-#          spec:
-#            pod_type: nonvppcontainer
-#            interfaces:
-#              - name: bia
-#                if_type: veth
-#                ipam_pool_names:
-#                  - network_service_pool
       connections:
         - conn_type: l2pp
           pod_interfaces:
             - MOB/mob
           node_interface_labels:
             - mob_label
-#        - conn_type: l2mp
-#          pod_interfaces:
-#            - MOB/bia
-#            - BIA_1/bia
-#            - BIA_2/bia
-#          network_node_overlay_name: inter_node_vxlan_mesh
 
 network_node_overlays:
   - metadata:
@@ -114,5 +61,4 @@ network_node_overlays:
       vxlan_mesh_parms:
         vni_range_start: 5000
         vni_range_end: 5999
-        #loopback_ipam_pool_name: vxlan_loopback_pool
         network_node_interface_label: vxlan


### PR DESCRIPTION
This commit is inspired by a similar commit to Network Service Mesh [1] and
this commit [2] from cn-infra, as well as this commit [3] from contiv-vpp
and this one [4] from vpp-agent.

Since we are making heavy use of yaml files for Network Service Mesh, we should
ensure these are syntactically correct. We'll use yamllint [5] for this.

This commit adds running of yamllint into our travis-ci runs. It also adds a
custom configuration file which turns the yamllint line length check into a
warning. And finally, it fixes a large amount of yamllint errors in our
existing yaml files.

[1] ligato/networkservicemesh#263
[2] ligato/cn-infra#333
[3] ligato/vpp-agent#820
[4] contiv/vpp#1051
[5] https://github.com/adrienverge/yamllint

Signed-off-by: Kyle Mestery <mestery@mestery.com>