### PR TITLE
Fix some bugs & Change the glide app install way

### DIFF
--- a/docker/dev_sfc_controller_alpine/Dockerfile
+++ b/docker/dev_sfc_controller_alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine3.6
+FROM golang:1.11-alpine3.9
 
 #RUN apk info
 #RUN apk update
@@ -25,8 +25,11 @@ RUN cd protobuf && make install
 RUN cd protobuf && ls
 RUN rm -rf protobuf
 
-COPY docker/dev_sfc_controller_alpine/build-glide.sh .
-RUN ./build-glide.sh
+#COPY docker/dev_sfc_controller_alpine/build-glide.sh .
+#RUN ./build-glide.sh
+RUN mkdir $GOPATH/src/github.com && mkdir $GOPATH/src/github.com/Masterminds
+RUN cd $GOPATH/src/github.com/Masterminds && git clone https://github.com/Masterminds/glide.git
+RUN cd $GOPATH/src/github.com/Masterminds/glide && make install
 
 COPY / /root/go/src/github.com/ligato/sfc-controller/
 COPY docker/dev_sfc_controller_alpine/build-controller.sh .

--- a/docker/prod_sfc_controller_alpine/Dockerfile
+++ b/docker/prod_sfc_controller_alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.9
 
 # use /opt/vnf-agent/dev as the working directory
 RUN mkdir -p /opt/sfc-controller/dev


### PR DESCRIPTION
In this patch, it will resolve 2 problems.
1. The sfc-controller image of alpine version builds failure.
   It needs to update the golang build version from 1.9 to 1.11.

2. The alpine sfc-controller multi-arch image can not be build.
   This issue is caused by that the arm64 platform is not well
   supported by glide installalation shell scrpts. So it will be
   installed from source code.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>